### PR TITLE
friends.nico is abolished

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -6,7 +6,7 @@ function load() {
     let instances = loadInstances();
     if (instances.length == 0) {
         // add default instances
-        instances = ["mstdn.jp", "friends.nico", "pawoo.net"];
+        instances = ["mstdn.jp", "pawoo.net"];
         saveInstances(instances);
     }
     let lastSelect = localStorage.getItem("lastSelected");


### PR DESCRIPTION
friends.nico is abolished at April 28th 2019.
Therefore, it should not be displayed by default